### PR TITLE
Non-root/admin user can updates themselves but no one else.

### DIFF
--- a/src/RESTAPI/RESTAPI_user_handler.cpp
+++ b/src/RESTAPI/RESTAPI_user_handler.cpp
@@ -163,6 +163,11 @@ namespace OpenWifi {
 			return NotFound();
 		}
 
+		// Non-admin/root user is attempting to modify a user that is not themselves
+		if ((UserInfo_.userinfo.userRole != SecurityObjects::USER_ROLE::ADMIN && UserInfo_.userinfo.userRole != SecurityObjects::USER_ROLE::ROOT) && (UserInfo_.userinfo.id != Id)) {
+			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
+		}
+
 		if (!ACLProcessor::Can(UserInfo_.userinfo, Existing, ACLProcessor::MODIFY)) {
 			return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 		}

--- a/src/RESTObjects/RESTAPI_SecurityObjects.h
+++ b/src/RESTObjects/RESTAPI_SecurityObjects.h
@@ -61,7 +61,8 @@ namespace OpenWifi {
 		};
 
 		const std::map<std::string, std::set<std::string>> API_WHITELIST = {
-			{"/api/v1/oauth2", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}}
+			{"/api/v1/oauth2", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}},
+			{"/api/v1/user", {Poco::Net::HTTPRequest::HTTP_PUT}}
 		};
 
 		enum USER_ROLE {


### PR DESCRIPTION
**Description:**
Non-admin/root users can update their own user info but no one else. Admin/root user can update anyone's user info.

**Trello link:**
https://trello.com/c/Qi9VDbtj/455-owsec-csr-user-should-be-able-to-update-their-own-user-info

**Summary of Changes:**
- Add API to whitelist
- Add check in PUT user API to compare user type and ID against request

